### PR TITLE
Jetpack3.1 + Python 3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Aug 11, 2017
 Install TensorFlow v1.0.1 on NVIDIA Jetson TX2 Development Kit
 
 Jetson TX2 is flashed with JetPack 3.1 which installs:
-* L4T 27.1 an Ubuntu 16.04 64-bit variant (aarch64)
+* L4T 28.1 an Ubuntu 16.04 64-bit variant (aarch64)
 * CUDA 8.0
 * cuDNN 6.0.21
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # installTensorFlowTX2
-April 1, 2017
+Aug 11, 2017
 Install TensorFlow v1.0.1 on NVIDIA Jetson TX2 Development Kit
 
-Jetson TX2 is flashed with JetPack 3.0 which installs:
+Jetson TX2 is flashed with JetPack 3.1 which installs:
 * L4T 27.1 an Ubuntu 16.04 64-bit variant (aarch64)
 * CUDA 8.0
-* cuDNN 5.1.10
+* cuDNN 6.0.21
 
 ### Installation
 Before installing TensorFlow, a swap file should be created (minimum of 8GB recommended). The Jetson TX2 does not have enough physical memory to compile TensorFlow. The swap file may be located on the internal eMMC, and may be removed after the build.
@@ -30,7 +30,7 @@ Builds version 0.4.5. Includes patches for compiling under aarch64.
 Git clones v1.0.1 from the TensorFlow repository and patches the source code for aarch64
 
 #### setTensorFlowEV.sh
-Sets up the TensorFlow environment variables. This script will ask for the default python library path. There are many settings to chose from, the script picks the usual suspects. Uses python 2.7.
+Sets up the TensorFlow environment variables. This script will ask for the default python library path. There are many settings to chose from, the script picks the usual suspects. Uses python 3.5.
 
 #### buildTensorFlow.sh
 Builds TensorFlow.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # installTensorFlowTX2
 Aug 11, 2017
-Install TensorFlow v1.0.1 on NVIDIA Jetson TX2 Development Kit
+Install TensorFlow v1.2.1 on NVIDIA Jetson TX2 Development Kit
 
 Jetson TX2 is flashed with JetPack 3.1 which installs:
 * L4T 28.1 an Ubuntu 16.04 64-bit variant (aarch64)
@@ -27,7 +27,7 @@ Installs Java and other dependencies needed. Also builds:
 Builds version 0.4.5. Includes patches for compiling under aarch64. 
 
 #### cloneTensorFlow.sh
-Git clones v1.0.1 from the TensorFlow repository and patches the source code for aarch64
+Git clones v1.2.1 from the TensorFlow repository and patches the source code for aarch64
 
 #### setTensorFlowEV.sh
 Sets up the TensorFlow environment variables. This script will ask for the default python library path. There are many settings to chose from, the script picks the usual suspects. Uses python 3.5.

--- a/buildTensorFlow.sh
+++ b/buildTensorFlow.sh
@@ -6,7 +6,7 @@
 export TF_NEED_CUDA=1
 export TF_CUDA_VERSION=8.0
 export CUDA_TOOLKIT_PATH=/usr/local/cuda
-export TF_CUDNN_VERSION=5.1.10
+export TF_CUDNN_VERSION=6.0.21
 export CUDNN_INSTALL_PATH=/usr/lib/aarch64-linux-gnu/
 export TF_CUDA_COMPUTE_CAPABILITIES=6.2
 

--- a/cloneTensorFlow.sh
+++ b/cloneTensorFlow.sh
@@ -8,7 +8,7 @@ INSTALL_DIR=$PWD
 cd $HOME
 git clone https://github.com/tensorflow/tensorflow.git
 cd tensorflow
-git checkout v1.0.1
+git checkout v1.2.1
 patch -p1 < $INSTALL_DIR/patches/tensorflow.patch
 
 

--- a/createSwapfile.sh
+++ b/createSwapfile.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+#NVIDIA Jetson TX1
+# Create a swap file and set up permissions
+# If a parameter is passed, it should be the place to create the swapfile
+SWAPDIRECTORY=$PWD
+SWAPSIZE=8
+AUTOMOUNT="N"
+function usage
+{
+    echo "usage: createSwapFile [[[-d directory ] [-s size] -a] | [-h]]"
+    echo "-d | --dir <directoryname>   Directory to place swapfile"
+    echo "-s | --size <gigabytes>"
+    echo "-a | --auto  Enable swap on boot in /etc/fstab "
+    echo "-h | --help  This message"
+}
+
+while [ "$1" != "" ]; do
+    case $1 in
+        -d | --dir )            shift
+                                SWAPDIRECTORY=$1
+                                ;;
+        -s | --size )           shift 
+				SWAPSIZE=$1
+                                ;;
+        -a | --auto )           AUTOMOUNT="Y"
+				;;
+        -h | --help )           usage
+                                exit
+                                ;;
+        * )                     usage
+                                exit 1
+    esac
+    shift
+done
+
+echo "Creating Swapfile at: " $SWAPDIRECTORY
+echo "Swapfile Size: " $SWAPSIZE"G"
+echo "Automount: " $AUTOMOUNT
+
+#Create a swapfile for Ubuntu at the current directory location
+fallocate -l $SWAPSIZE"G" $SWAPDIRECTORY"/swapfile"
+cd $SWAPDIRECTORY
+#List out the file
+ls -lh swapfile
+# Change permissions so that only root can use it
+sudo chmod 600 swapfile
+#List out the file
+ls -lh swapfile
+#Set up the Linux swap area
+sudo mkswap swapfile
+#Now start using the swapfile
+sudo swapon swapfile
+#Show that it's now being used
+swapon -s
+
+if [ "$AUTOMOUNT" = "Y" ]; then
+	echo "Modifying /etc/fstab to enable on boot"
+        SWAPLOCATION=$SWAPDIRECTORY"/swapfile"
+        echo $SWAPLOCATION
+	sudo sh -c 'echo "'$SWAPLOCATION' none swap sw 0 0" >> /etc/fstab'
+fi
+

--- a/packageTensorFlow.sh
+++ b/packageTensorFlow.sh
@@ -2,5 +2,5 @@
 # NVIDIA Jetson TX1
 cd $HOME/tensorflow
 bazel-bin/tensorflow/tools/pip_package/build_pip_package /tmp/tensorflow_pkg
-mv /tmp/tensorflow_pkg/tensorflow-1.0.1-cp35-cp35-linux_aarch64.whl $HOME/
+mv /tmp/tensorflow_pkg/tensorflow-1.2.1-cp35-cp35m-linux_aarch64.whl $HOME/
 

--- a/packageTensorFlow.sh
+++ b/packageTensorFlow.sh
@@ -2,5 +2,5 @@
 # NVIDIA Jetson TX1
 cd $HOME/tensorflow
 bazel-bin/tensorflow/tools/pip_package/build_pip_package /tmp/tensorflow_pkg
-mv /tmp/tensorflow_pkg/tensorflow-1.0.1-cp27-cp27mu-linux_aarch64.whl $HOME/
+mv /tmp/tensorflow_pkg/tensorflow-1.0.1-cp35-cp35-linux_aarch64.whl $HOME/
 

--- a/setTensorFlowEV.sh
+++ b/setTensorFlowEV.sh
@@ -27,7 +27,6 @@ TF_CUDA_VERSION=8.0
 default_cuda_path=/usr/local/cuda
 CUDA_TOOLKIT_PATH=$default_cuda_path
 # cuDNN
-#TF_CUDNN_VERSION=5.1.10
 TF_CUDNN_VERSION=6.0.21
 default_cudnn_path=/usr/lib/aarch64-linux-gnu
 CUDNN_INSTALL_PATH=$default_cudnn_path

--- a/setTensorFlowEV.sh
+++ b/setTensorFlowEV.sh
@@ -10,7 +10,7 @@ sudo mkdir /usr/lib/aarch64-linux-gnu/include/
 sudo cp /usr/include/cudnn.h /usr/lib/aarch64-linux-gnu/include/cudnn.h
 # Setup the environment variables for configuration
 # PYTHON Path is the default
-default_python_bin_path=$(which python)
+default_python_bin_path=$(which python3)
 PYTHON_BIN_PATH=$default_python_bin_path
 # No Google Cloud Platform support
 TF_NEED_GCP=0
@@ -27,7 +27,8 @@ TF_CUDA_VERSION=8.0
 default_cuda_path=/usr/local/cuda
 CUDA_TOOLKIT_PATH=$default_cuda_path
 # cuDNN
-TF_CUDNN_VERSION=5.1.10
+#TF_CUDNN_VERSION=5.1.10
+TF_CUDNN_VERSION=6.0.21
 default_cudnn_path=/usr/lib/aarch64-linux-gnu
 CUDNN_INSTALL_PATH=$default_cudnn_path
 # CUDA compute capability


### PR DESCRIPTION
This pull request has tested installation on tx2 with Jetpack3.1 + Python 3.5. You could tag this version.

Note: sometime later i'm going to build TF 1.2.1 instead.

Would it be a good idea to also release a wheel with package version well documented? I think that way people can try the binary first. If that doesn't work, then spend some time on compilation.